### PR TITLE
ECR-1450-minor-flexibility

### DIFF
--- a/src/it/defaultValues/pom.xml
+++ b/src/it/defaultValues/pom.xml
@@ -30,6 +30,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <defaultValues>default.package.json</defaultValues>
+                    <typeScriptVersion>5.7.3</typeScriptVersion>
                     <dependencies>
                         <dependency>
                             <name>@angular/core</name>

--- a/src/main/java/de/eitco/cicd/typescript/maven/plugin/AbstractTypescriptMojo.java
+++ b/src/main/java/de/eitco/cicd/typescript/maven/plugin/AbstractTypescriptMojo.java
@@ -310,9 +310,7 @@ public abstract class AbstractTypescriptMojo extends AbstractFrontendMojo {
 
         metaDataReader.forEachDependency((dependency, packaj) -> {
 
-            String version = packaj.getVersion().endsWith("-SNAPSHOT")
-                    ? '~' + packaj.getVersion()
-                    : packaj.getVersion();
+            String version = '~' + packaj.getVersion();
 
             projectBuilder.addPeerDependency(
                     packaj.getName(),

--- a/src/main/java/de/eitco/cicd/typescript/maven/plugin/AbstractTypescriptMojo.java
+++ b/src/main/java/de/eitco/cicd/typescript/maven/plugin/AbstractTypescriptMojo.java
@@ -310,7 +310,7 @@ public abstract class AbstractTypescriptMojo extends AbstractFrontendMojo {
 
         metaDataReader.forEachDependency((dependency, packaj) -> {
 
-            String version = '~' + packaj.getVersion();
+            String version = '^' + packaj.getVersion();
 
             projectBuilder.addPeerDependency(
                     packaj.getName(),


### PR DESCRIPTION
Allow minor flexibility for peer dependencies added via maven dependencies to enable npm to install peer dependencies automatically.