### PR TITLE
ECR-1486: peerDependencies with greater equal version operator

### DIFF
--- a/src/main/java/de/eitco/cicd/typescript/maven/plugin/AbstractTypescriptMojo.java
+++ b/src/main/java/de/eitco/cicd/typescript/maven/plugin/AbstractTypescriptMojo.java
@@ -310,7 +310,7 @@ public abstract class AbstractTypescriptMojo extends AbstractFrontendMojo {
 
         metaDataReader.forEachDependency((dependency, packaj) -> {
 
-            String version = '^' + packaj.getVersion();
+            String version = '>=' + packaj.getVersion();
 
             projectBuilder.addPeerDependency(
                     packaj.getName(),

--- a/src/main/java/de/eitco/cicd/typescript/maven/plugin/AbstractTypescriptMojo.java
+++ b/src/main/java/de/eitco/cicd/typescript/maven/plugin/AbstractTypescriptMojo.java
@@ -310,7 +310,7 @@ public abstract class AbstractTypescriptMojo extends AbstractFrontendMojo {
 
         metaDataReader.forEachDependency((dependency, packaj) -> {
 
-            String version = '>=' + packaj.getVersion();
+            String version = ">=" + packaj.getVersion();
 
             projectBuilder.addPeerDependency(
                     packaj.getName(),


### PR DESCRIPTION
The version of a peer dependency added via maven should be set to greater than or equal in the final package.json.